### PR TITLE
fix query_country_alsi_storage

### DIFF
--- a/src/roiti/gie/gie_raw_client.py
+++ b/src/roiti/gie/gie_raw_client.py
@@ -205,7 +205,7 @@ class GieRawClient:
 
         self._logger.info("Query ALSI COUNTRY STORAGE started..")
         return await self.fetch(
-            APIType.AGSI,
+            APIType.ALSI,
             params=params,
             start=start,
             end=end,


### PR DESCRIPTION
There seems to be a copy paste issue in the `query_country_alsi_storage` which makes it give the same result as for the AGSI query.